### PR TITLE
Fix and link version information in Readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,8 +1,7 @@
 * ⚠ Integration into Emas core
 
-This project got integrated into Emacs core after the release of Emacs
-27.1. Please contribute patches to Emacs core directly instead of
-here.
+This project got integrated into Emacs core in release [[https://www.gnu.org/savannah-checkouts/gnu/emacs/news/NEWS.28.1][28.1]].
+Please contribute patches to Emacs core directly instead of here.
 
 * Hierarchy
   #+BEGIN_HTML


### PR DESCRIPTION
Hi,

I tried to track down where in emacs core this hierarchy was added and found that it was not in 27.1 (as hinted at in the Readme) but 28.1

https://www.gnu.org/savannah-checkouts/gnu/emacs/news/NEWS.28.1

Obviously I am aware that this repo is not meant to be contributed to anymore, but I think the warning about this very thing should be as precise as possible,